### PR TITLE
log steal_time

### DIFF
--- a/graphite-probe-linux.py
+++ b/graphite-probe-linux.py
@@ -121,9 +121,11 @@ def probe_cpu():
             end_user = int(parts[1])
             end_system = int(parts[3])
             end_iowait = int(parts[5])
+            steal_time = int(parts[8])
     yield ('cpu.time.user_seconds_count', percent(end_user, cpu_count))
     yield ('cpu.time.system_seconds_count', percent(end_system, cpu_count))
     yield ('cpu.time.iowait_seconds_count', percent(end_iowait, cpu_count))
+    yield ('cpu.time.steal_time_count', percent(steal_time, cpu_count))
 
 
 def probe_load():


### PR DESCRIPTION
`steal_time` is time that the VM is ready to run but could not due to
another VM on the same physical host competing for the CPU.

We've been burned by this a few times on Linode and it's potentially an
issue on EC2 as well so we really ought to be tracking it.